### PR TITLE
Add vector field support

### DIFF
--- a/znvis/__init__.py
+++ b/znvis/__init__.py
@@ -28,12 +28,16 @@ from znvis.material.material import Material
 from znvis.mesh.custom import CustomMesh
 from znvis.mesh.cylinder import Cylinder
 from znvis.mesh.sphere import Sphere
+from znvis.mesh.arrow import Arrow
 from znvis.particle.particle import Particle
+from znvis.particle.vector_field import VectorField
 from znvis.visualizer.visualizer import Visualizer
 
 __all__ = [
     Particle.__name__,
     Sphere.__name__,
+    Arrow.__name__,
+    VectorField.__name__,
     Visualizer.__name__,
     Cylinder.__name__,
     CustomMesh.__name__,

--- a/znvis/mesh/arrow.py
+++ b/znvis/mesh/arrow.py
@@ -1,0 +1,89 @@
+"""
+ZnVis: A Zincwarecode package.
+License
+-------
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License v2.0 which accompanies this distribution, and is
+available at https://www.eclipse.org/legal/epl-v20.html
+SPDX-License-Identifier: EPL-2.0
+Copyright Contributors to the Zincwarecode Project.
+Contact Information
+-------------------
+email: zincwarecode@gmail.com
+github: https://github.com/zincware
+web: https://zincwarecode.com/
+Citation
+--------
+If you use this module please cite us with:
+
+Summary
+-------
+Create a sphere mesh.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import open3d as o3d
+
+from znvis.transformations.rotation_matrices import rotation_matrix
+
+from .mesh import Mesh
+
+
+@dataclass
+class Arrow(Mesh):
+    """
+    A class to produce arrow meshes.
+
+    Attributes
+    ----------
+    scale : float
+            Scale of the arrow
+    """
+    scale: float = 1.0
+    resolution = 10
+
+    def create_mesh(
+        self, starting_position: np.ndarray, direction: np.ndarray = None
+    ) -> o3d.geometry.TriangleMesh:
+        """
+        Create a mesh object defined by the dataclass.
+
+        Parameters
+        ----------
+        starting_position : np.ndarray shape=(3,)
+                Starting position of the mesh.
+        direction : np.ndarray shape=(3,) (default = None)
+                Direction of the mesh.
+
+        Returns
+        -------
+        mesh : o3d.geometry.TriangleMesh
+        """
+
+        # Calculate the length of the direction vector
+        direction_length = np.linalg.norm(direction)
+
+        # Scale the arrow size with the direction length
+        cylinder_radius = 0.06 * direction_length * self.scale
+        cylinder_height = 0.85 * direction_length * self.scale
+        cone_radius = 0.15 * direction_length * self.scale
+        cone_height = 0.15 * direction_length * self.scale
+
+
+        arrow = o3d.geometry.TriangleMesh.create_arrow(
+            cylinder_radius=cylinder_radius, 
+            cylinder_height=cylinder_height, 
+            cone_radius=cone_radius, 
+            cone_height=cone_height,
+            resolution=self.resolution
+        )
+
+        arrow.compute_vertex_normals()
+        matrix = rotation_matrix(np.array([0, 0, 1]), direction)
+        arrow.rotate(matrix)
+
+        arrow.translate(starting_position.astype(float) + direction * 0.5 * self.scale)
+
+        return arrow

--- a/znvis/mesh/arrow.py
+++ b/znvis/mesh/arrow.py
@@ -79,7 +79,7 @@ class Arrow(Mesh):
 
         arrow.compute_vertex_normals()
         matrix = rotation_matrix(np.array([0, 0, 1]), direction)
-        arrow.rotate(matrix)
+        arrow.rotate(matrix, center=(0, 0, 0))
 
         # Translate the arrow to the starting position and center the origin
         arrow.translate(starting_position.astype(float) + direction * 0.5 * self.scale)

--- a/znvis/mesh/arrow.py
+++ b/znvis/mesh/arrow.py
@@ -62,15 +62,12 @@ class Arrow(Mesh):
         mesh : o3d.geometry.TriangleMesh
         """
 
-        # Calculate the length of the direction vector
         direction_length = np.linalg.norm(direction)
 
-        # Scale the arrow size with the direction length
         cylinder_radius = 0.06 * direction_length * self.scale
         cylinder_height = 0.85 * direction_length * self.scale
         cone_radius = 0.15 * direction_length * self.scale
         cone_height = 0.15 * direction_length * self.scale
-
 
         arrow = o3d.geometry.TriangleMesh.create_arrow(
             cylinder_radius=cylinder_radius, 
@@ -84,6 +81,7 @@ class Arrow(Mesh):
         matrix = rotation_matrix(np.array([0, 0, 1]), direction)
         arrow.rotate(matrix)
 
+        # Translate the arrow to the starting position and center the origin
         arrow.translate(starting_position.astype(float) + direction * 0.5 * self.scale)
 
         return arrow

--- a/znvis/mesh/arrow.py
+++ b/znvis/mesh/arrow.py
@@ -28,7 +28,7 @@ import open3d as o3d
 
 from znvis.transformations.rotation_matrices import rotation_matrix
 
-from .mesh import Mesh
+from znvis.mesh import Mesh
 
 
 @dataclass
@@ -40,9 +40,11 @@ class Arrow(Mesh):
     ----------
     scale : float
             Scale of the arrow
+    resolution : int
+            Resolution of the mesh.
     """
     scale: float = 1.0
-    resolution = 10
+    resolution: int = 10
 
     def create_mesh(
         self, starting_position: np.ndarray, direction: np.ndarray = None

--- a/znvis/mesh/arrow.py
+++ b/znvis/mesh/arrow.py
@@ -82,6 +82,6 @@ class Arrow(Mesh):
         arrow.rotate(matrix, center=(0, 0, 0))
 
         # Translate the arrow to the starting position and center the origin
-        arrow.translate(starting_position.astype(float) + direction * 0.5 * self.scale)
+        arrow.translate(starting_position.astype(float))
 
         return arrow

--- a/znvis/particle/vector_field.py
+++ b/znvis/particle/vector_field.py
@@ -1,0 +1,110 @@
+"""
+ZnVis: A Zincwarecode package.
+License
+-------
+This program and the accompanying materials are made available under the terms
+of the Eclipse Public License v2.0 which accompanies this distribution, and is
+available at https://www.eclipse.org/legal/epl-v20.html
+SPDX-License-Identifier: EPL-2.0
+Copyright Contributors to the Zincwarecode Project.
+Contact Information
+-------------------
+email: zincwarecode@gmail.com
+github: https://github.com/zincware
+web: https://zincwarecode.com/
+Citation
+--------
+If you use this module please cite us with:
+
+Summary
+-------
+Module for the particle parent class
+"""
+
+import typing
+from dataclasses import dataclass
+
+import numpy as np
+from rich.progress import track
+
+from znvis.mesh import Mesh
+
+
+@dataclass
+class VectorField:
+    """
+    Parent class for a ZnVis particle.
+
+    Attributes
+    ----------
+    name : str
+            Name of the particle
+    mesh : Mesh
+            Mesh to use e.g. sphere
+    position : np.ndarray
+            Position tensor of the shape (n_confs, n_particles, n_dims)
+
+    mesh_list : list
+            A list of mesh objects, one for each time step.
+    smoothing : bool (default=False)
+            If true, apply smoothing to each mesh object as it is rendered.
+            This will slow down the initial construction of the mesh objects
+            but not the deployment.
+    """
+
+    name: str
+    mesh: Mesh = None
+    position: np.ndarray = None
+    direction: np.ndarray = None
+    mesh_list: typing.List[Mesh] = None
+
+    smoothing: bool = False
+
+    def _create_mesh(self, position, direction):
+        """
+        Create a mesh object for the particle.
+
+        Parameters
+        ----------
+        position : np.ndarray
+                Position of the particle
+        director : np.ndarray
+                Director of the particle
+
+        Returns
+        -------
+        mesh : o3d.geometry.TriangleMesh
+                A mesh object
+        """
+        
+        mesh = self.mesh.create_mesh(position, direction)
+        if self.smoothing:
+            return mesh.filter_smooth_taubin(100)
+        else:
+            return mesh
+
+    def construct_mesh_list(self):
+        """
+        Constructor the mesh list for the class.
+
+        The mesh list is a list of mesh objects for each
+        time step in the parsed trajectory.
+
+        Returns
+        -------
+        Updates the class attributes mesh_list
+        """
+        self.mesh_list = []
+        try:
+            n_particles = int(self.position.shape[1])
+            n_time_steps = int(self.position.shape[0])
+        except ValueError:
+            raise ValueError("There is no data for these particles.")
+
+        for i in track(range(n_time_steps), description=f"Building {self.name} Mesh"):
+            for j in range(n_particles):
+                if j == 0:
+                    mesh = self._create_mesh(self.position[i][j], self.direction[i][j])
+                else:
+                    mesh += self._create_mesh(self.position[i][j], self.direction[i][j])
+            self.mesh_list.append(mesh)

--- a/znvis/particle/vector_field.py
+++ b/znvis/particle/vector_field.py
@@ -61,7 +61,7 @@ class VectorField:
 
     smoothing: bool = False
 
-    def _create_mesh(self, position, direction):
+    def _create_mesh(self, position: np.ndarray, direction: np.ndarray):
         """
         Create a mesh object for the vector field.
 

--- a/znvis/particle/vector_field.py
+++ b/znvis/particle/vector_field.py
@@ -27,23 +27,24 @@ from dataclasses import dataclass
 import numpy as np
 from rich.progress import track
 
-from znvis.mesh import Mesh
+from znvis.mesh.arrow import Arrow
 
 
 @dataclass
 class VectorField:
     """
-    Parent class for a ZnVis particle.
+    A class to represent a vector field.
 
     Attributes
     ----------
     name : str
-            Name of the particle
+            Name of the vector field
     mesh : Mesh
-            Mesh to use e.g. sphere
+            Mesh to use 
     position : np.ndarray
-            Position tensor of the shape (n_confs, n_particles, n_dims)
-
+            Position tensor of the shape (n_steps, n_vectors, n_dims)
+    direction : np.ndarray
+            Direction tensor of the shape (n_steps, n_vectors, n_dims)
     mesh_list : list
             A list of mesh objects, one for each time step.
     smoothing : bool (default=False)
@@ -53,23 +54,23 @@ class VectorField:
     """
 
     name: str
-    mesh: Mesh = None
+    mesh: Arrow = None # Should be an instance of the Arrow class
     position: np.ndarray = None
     direction: np.ndarray = None
-    mesh_list: typing.List[Mesh] = None
+    mesh_list: typing.List[Arrow] = None
 
     smoothing: bool = False
 
     def _create_mesh(self, position, direction):
         """
-        Create a mesh object for the particle.
+        Create a mesh object for the vector field.
 
         Parameters
         ----------
         position : np.ndarray
-                Position of the particle
-        director : np.ndarray
-                Director of the particle
+                Position of the arrow
+        direction : np.ndarray
+                Direction of the arrow
 
         Returns
         -------
@@ -99,7 +100,7 @@ class VectorField:
             n_particles = int(self.position.shape[1])
             n_time_steps = int(self.position.shape[0])
         except ValueError:
-            raise ValueError("There is no data for these particles.")
+            raise ValueError("There is no data for this vector field.")
 
         for i in track(range(n_time_steps), description=f"Building {self.name} Mesh"):
             for j in range(n_particles):

--- a/znvis/visualizer/visualizer.py
+++ b/znvis/visualizer/visualizer.py
@@ -547,8 +547,9 @@ class Visualizer:
 
         self._draw_particles(visualizer=visualizer)  # draw the particles.
 
+        # draw the vector field if it exists.
         if self.vector_field is not None:
-            self._draw_vector_field(visualizer=visualizer)
+            self._draw_vector_field(visualizer=visualizer) 
 
         visualizer.post_redraw()  # re-draw the window.
 


### PR DESCRIPTION
This adds vector field support by:

- Adding a new arrow mesh with the `scale` parameter
- `VectorField` class that is analogue to `Particle` but contains different parameter `direction` for the direction of the vectors. The current design is such that each position is assigned the corresponding direction vector in the list of given positions and vectors.
- optional `vector_field`  parameter for the `visualizer` that works the same as `particles`, but is declared seperately and takes in a `VectorField` instance

Note that the initial rendering is quite slow for large numbers of vectors. This could be optimized somehow.

Example Syntax:
```
v_mat = vis.Material(colour=np.array([0, 0, 255]) / 255)
v_mesh = vis.Arrow(scale = 10, material = v_mat)
v_field = vis.VectorField(name="flow", mesh=v_mesh, position=pos, direction=dir)

visualizer = vis.Visualizer(particles=[...], vector_field=[v_field], frame_rate=30)
```
The variables `pos` and `dir` are of the shape (n_steps, n_vectors, n_dims = 3)