### PR TITLE
[WIP] Static mesh support

### DIFF
--- a/znvis/particle/vector_field.py
+++ b/znvis/particle/vector_field.py
@@ -113,10 +113,16 @@ class VectorField:
         except ValueError:
             raise ValueError("There is no data for this vector field.")
 
+        new_mesh = True
+
         for i in track(range(n_time_steps), description=f"Building {self.name} Mesh"):
             for j in range(n_particles):
-                if j == 0:
-                    mesh = self._create_mesh(self.position[i][j], self.direction[i][j])
-                else:
-                    mesh += self._create_mesh(self.position[i][j], self.direction[i][j])
+                if np.max(self.direction[i][j]) > 0: # ignore vectors with length zero
+                    if new_mesh is False:
+                        mesh += self._create_mesh(self.position[i][j], self.direction[i][j])
+                    else:
+                        mesh = self._create_mesh(self.position[i][j], self.direction[i][j])
+                        new_mesh = False
+            new_mesh = True
+
             self.mesh_list.append(mesh)

--- a/znvis/particle/vector_field.py
+++ b/znvis/particle/vector_field.py
@@ -47,6 +47,10 @@ class VectorField:
             Direction tensor of the shape (n_steps, n_vectors, n_dims)
     mesh_list : list
             A list of mesh objects, one for each time step.
+    static : bool (default=False)
+            If true, only render the mesh once at initialization. Be careful
+            as this changes the shape of the required position and direction 
+            to (n_particles, n_dims) 
     smoothing : bool (default=False)
             If true, apply smoothing to each mesh object as it is rendered.
             This will slow down the initial construction of the mesh objects
@@ -58,7 +62,7 @@ class VectorField:
     position: np.ndarray = None
     direction: np.ndarray = None
     mesh_list: typing.List[Arrow] = None
-
+    static: bool = False
     smoothing: bool = False
 
     def _create_mesh(self, position: np.ndarray, direction: np.ndarray):
@@ -97,8 +101,15 @@ class VectorField:
         """
         self.mesh_list = []
         try:
-            n_particles = int(self.position.shape[1])
-            n_time_steps = int(self.position.shape[0])
+            if not self.static: 
+                n_particles = int(self.position.shape[1])
+                n_time_steps = int(self.position.shape[0])
+            else:
+                n_particles = int(self.position.shape[0])
+                n_time_steps = 1
+                self.position = self.position[np.newaxis, :, :]
+                self.direction = self.direction[np.newaxis, :, :]
+
         except ValueError:
             raise ValueError("There is no data for this vector field.")
 

--- a/znvis/visualizer/visualizer.py
+++ b/znvis/visualizer/visualizer.py
@@ -377,10 +377,11 @@ class Visualizer:
                 )
         else:
             for i, item in enumerate(self.vector_field):
-                visualizer.remove_geometry(item.name)
-                visualizer.add_geometry(
-                    item.name, item.mesh_list[self.counter], item.mesh.o3d_material
-                )
+                if not item.static:
+                    visualizer.remove_geometry(item.name)
+                    visualizer.add_geometry(
+                        item.name, item.mesh_list[self.counter], item.mesh.o3d_material
+                    )
 
     def _continuous_trajectory(self, vis):
         """
@@ -416,19 +417,34 @@ class Visualizer:
             """
             mesh_dict = {}
 
-            for item in self.vector_field:
-                mesh_dict[item.name] = {
-                    "mesh": item.mesh_list[self.counter],
-                    "bsdf": item.mesh.material.mitsuba_bsdf,
-                    "material": item.mesh.o3d_material,
-                }
+            if self.vector_field is not None:
+                for item in self.vector_field:
+                    if item.static:
+                        mesh_dict[item.name] = {
+                        "mesh": item.mesh_list[0],
+                        "bsdf": item.mesh.material.mitsuba_bsdf,
+                        "material": item.mesh.o3d_material,
+                    }
+                    else:
+                        mesh_dict[item.name] = {
+                            "mesh": item.mesh_list[self.counter],
+                            "bsdf": item.mesh.material.mitsuba_bsdf,
+                            "material": item.mesh.o3d_material,
+                        }
             
             for item in self.particles:
-                mesh_dict[item.name] = {
-                    "mesh": item.mesh_list[self.counter],
-                    "bsdf": item.mesh.material.mitsuba_bsdf,
-                    "material": item.mesh.o3d_material,
+                if item.static:
+                    mesh_dict[item.name] = {
+                        "mesh": item.mesh_list[0],
+                        "bsdf": item.mesh.material.mitsuba_bsdf,
+                        "material": item.mesh.o3d_material,
                 }
+                else:
+                    mesh_dict[item.name] = {
+                        "mesh": item.mesh_list[self.counter],
+                        "bsdf": item.mesh.material.mitsuba_bsdf,
+                        "material": item.mesh.o3d_material,
+                    }
 
             view_matrix = self.vis.scene.camera.get_view_matrix()
             self.renderer.render_mesh_objects(

--- a/znvis/visualizer/visualizer.py
+++ b/znvis/visualizer/visualizer.py
@@ -95,8 +95,11 @@ class Visualizer:
         self.bounding_box = bounding_box() if bounding_box else None
 
         if number_of_steps is None:
-            number_of_steps = len(particles[0].position)
-        self.number_of_steps = number_of_steps
+            len_list = []
+            for particle in particles:
+                if not particle.static:
+                    len_list.append(len(particle.position))
+            self.number_of_steps = min(len_list)
 
         self.output_folder = pathlib.Path(output_folder).resolve()
         self.frame_folder = self.output_folder / "video_frames"

--- a/znvis/visualizer/visualizer.py
+++ b/znvis/visualizer/visualizer.py
@@ -513,10 +513,16 @@ class Visualizer:
             Function to be called on thread to save image.
             """
             for i, item in enumerate(self.particles):
-                if i == 0:
-                    mesh = item.mesh_list[self.counter]
+                if item.static:
+                    if i == 0:
+                        mesh = item.mesh_list[0]
+                    else:
+                        mesh += item.mesh_list[0]
                 else:
-                    mesh += item.mesh_list[self.counter]
+                    if i == 0:
+                        mesh = item.mesh_list[self.counter]
+                    else:
+                        mesh += item.mesh_list[self.counter]
 
             o3d.io.write_triangle_mesh(
                 (self.obj_folder / f"export_mesh_{self.counter}.ply").as_posix(), mesh

--- a/znvis/visualizer/visualizer.py
+++ b/znvis/visualizer/visualizer.py
@@ -346,10 +346,11 @@ class Visualizer:
                 visualizer.add_geometry("Box", self.bounding_box)
         else:
             for i, item in enumerate(self.particles):
-                visualizer.remove_geometry(item.name)
-                visualizer.add_geometry(
-                    item.name, item.mesh_list[self.counter], item.mesh.o3d_material
-                )
+                if not item.static:
+                    visualizer.remove_geometry(item.name)
+                    visualizer.add_geometry(
+                        item.name, item.mesh_list[self.counter], item.mesh.o3d_material
+                    )
 
 
     def _draw_vector_field(self, visualizer=None, initial: bool = False):
@@ -415,6 +416,13 @@ class Visualizer:
             """
             mesh_dict = {}
 
+            for item in self.vector_field:
+                mesh_dict[item.name] = {
+                    "mesh": item.mesh_list[self.counter],
+                    "bsdf": item.mesh.material.mitsuba_bsdf,
+                    "material": item.mesh.o3d_material,
+                }
+            
             for item in self.particles:
                 mesh_dict[item.name] = {
                     "mesh": item.mesh_list[self.counter],

--- a/znvis/visualizer/visualizer.py
+++ b/znvis/visualizer/visualizer.py
@@ -271,18 +271,35 @@ class Visualizer:
         old_state = self.interrupt  # get old state
         self.interrupt = 0  # stop live feed if running.
         mesh_dict = {}
-        mesh_center = []
+        
+        if self.vector_field is not None:
+            for item in self.vector_field:
+                if item.static:
+                    mesh_dict[item.name] = {
+                    "mesh": item.mesh_list[0],
+                    "bsdf": item.mesh.material.mitsuba_bsdf,
+                    "material": item.mesh.o3d_material,
+                }
+                else:
+                    mesh_dict[item.name] = {
+                        "mesh": item.mesh_list[self.counter],
+                        "bsdf": item.mesh.material.mitsuba_bsdf,
+                        "material": item.mesh.o3d_material,
+                    }
+        
         for item in self.particles:
-            mesh_dict[item.name] = {
-                "mesh": item.mesh_list[self.counter],
-                "bsdf": item.mesh.material.mitsuba_bsdf,
-                "material": item.mesh.o3d_material,
+            if item.static:
+                mesh_dict[item.name] = {
+                    "mesh": item.mesh_list[0],
+                    "bsdf": item.mesh.material.mitsuba_bsdf,
+                    "material": item.mesh.o3d_material,
             }
-            mesh_center.append(
-                item.mesh_list[self.counter]
-                .get_axis_aligned_bounding_box()
-                .get_center()
-            )
+            else:
+                mesh_dict[item.name] = {
+                    "mesh": item.mesh_list[self.counter],
+                    "bsdf": item.mesh.material.mitsuba_bsdf,
+                    "material": item.mesh.o3d_material,
+                }
 
         view_matrix = vis.scene.camera.get_view_matrix()
 


### PR DESCRIPTION
Add option for meshes to be static, meaning they will only be loaded in once and not changed during the following frames. This significantly improves rendering time for a larger non-moving mesh.

Can be added to `vis.Particle` and `vis.VectorField` by simply giving them the `static = True` parameter. 

Note that static objects only take in `position` in the shape of (n_part, n_dim)