### PR TITLE
Update open3d version constraint to allow newer versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-open3d==0.17.0
+open3d>=0.17.0
 numpy==1.26.4
 pytest
 rich


### PR DESCRIPTION
With pip, you can currently only install open3d version 0.19.0. 
This allows newer versions than 0.17.0 and fixes installation issues.

All tests for v0.19.0 have passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Relaxed the Open3D dependency to allow versions 0.17.0 and above, improving compatibility with newer environments.
  * All other dependencies remain unchanged (e.g., numpy, pytest, rich, opencv-python, mitsuba).
  * No user-facing behavior changes are expected from this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->