### PR TITLE
Fix parallel render path

### DIFF
--- a/CI/unit_tests/visualizer/test_parallel_render.py
+++ b/CI/unit_tests/visualizer/test_parallel_render.py
@@ -95,6 +95,8 @@ class TestParallelRender(unittest.TestCase):
 
         parallel_render_manager._start_worker_process(spec, "/tmp/state.pkl")
 
+        args = popen_mock.call_args.args[0]
+        self.assertEqual(args[2], "znvis.parallel_render.parallel_render_worker")
         env = popen_mock.call_args.kwargs["env"]
         self.assertEqual(env["CUDA_VISIBLE_DEVICES"], "3")
 

--- a/znvis/parallel_render/parallel_render_manager.py
+++ b/znvis/parallel_render/parallel_render_manager.py
@@ -157,7 +157,7 @@ def _start_worker_process(spec: _WorkerSpec, state_path: str):
         [
             sys.executable,
             "-m",
-            "znvis.visualizer.parallel.parallel_render_worker",
+            "znvis.parallel_render.parallel_render_worker",
             state_path,
             str(spec.gpu_id),
         ],


### PR DESCRIPTION
Forgot to adapt the parallel_render_manager import path to the refactoring. 
Added a test to not repeat this issue again.